### PR TITLE
Fix: Make WebSocket URL protocol-aware (ws/wss)

### DIFF
--- a/frontend-service/index.html
+++ b/frontend-service/index.html
@@ -44,7 +44,8 @@
   </main>
 
   <script>
-    const wsUrl = `ws://${window.location.hostname || 'localhost'}:8888`;
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${protocol}//${window.location.hostname || 'localhost'}:8888`;
     let ws = null;
     let currentResponse = '';
 


### PR DESCRIPTION
Fixes #11

## Summary
- Frontend used hardcoded `ws://` URL which caused mixed-content errors over HTTPS
- Now detects page protocol and uses `wss://` for HTTPS, `ws://` for HTTP

## Test Plan
- Open frontend over HTTP → WebSocket connects with `ws://`
- Open frontend over HTTPS → WebSocket connects with `wss://`
- No mixed-content errors in browser console